### PR TITLE
Automatically build image through Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Check Latest Metabase Version
+
+on:
+  schedule:
+    - cron: "0 * * * *" # Every hour
+  workflow_dispatch:     # Manual run
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest Metabase version
+        id: get_version
+        run: |
+          echo "Fetching latest Metabase release from GitHub..."
+          latest=$(curl -s https://api.github.com/repos/metabase/metabase/releases/latest | jq -r .tag_name)
+          echo "Latest Metabase version: $latest"
+          echo "version=$latest" >> $GITHUB_OUTPUT
+
+      - name: Output version
+        run: echo "Latest Metabase version is ${{ steps.get_version.outputs.version }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,14 @@
-name: Check Latest Metabase Version
+name: Check and Build Metabase ARM64
 
 on:
   schedule:
     - cron: "0 * * * *" # Every hour
-  workflow_dispatch:     # Manual run
+  workflow_dispatch:
 
 jobs:
-  check-version:
+  check-build-push:
     runs-on: ubuntu-latest
+
     steps:
       - name: Get latest Metabase version
         id: get_version
@@ -17,5 +18,44 @@ jobs:
           echo "Latest Metabase version: $latest"
           echo "version=$latest" >> $GITHUB_OUTPUT
 
-      - name: Output version
-        run: echo "Latest Metabase version is ${{ steps.get_version.outputs.version }}"
+      - name: Check if Docker tag already exists
+        id: check_docker
+        run: |
+          TAG=${{ steps.get_version.outputs.version }}
+          echo "Checking if Docker tag $TAG exists..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://hub.docker.com/v2/repositories/stephaneturquay/metabase-arm64/tags/$TAG)
+          echo "HTTP Status: $STATUS"
+          if [ "$STATUS" -eq 200 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Output result
+        run: |
+          echo "Docker tag exists? ${{ steps.check_docker.outputs.exists }}"
+
+      - name: Docker Login
+        if: steps.check_docker.outputs.exists == 'false'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker image
+        if: steps.check_docker.outputs.exists == 'false'
+        run: |
+          TAG=${{ steps.get_version.outputs.version }}
+          IMAGE=stephaneturquay/metabase-arm64
+
+          echo "🔧 Building image with tag $TAG..."
+          docker build --build-arg METABASE_VERSION=$TAG -t $IMAGE:$TAG .
+
+          echo "🚀 Pushing $TAG..."
+          docker push $IMAGE:$TAG
+
+          echo "🏷️ Tagging as latest..."
+          docker tag $IMAGE:$TAG $IMAGE:latest
+
+          echo "🚀 Pushing latest..."
+          docker push $IMAGE:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-# Use Java 21 with multi-architecture support (including ARM)
 FROM eclipse-temurin:21-jre
 
-# Set the working directory in the container
 WORKDIR /usr/src/metabase
 
-# Download the latest Metabase JAR from the official source
+# Default to 'latest' if not passed via --build-arg
+ARG METABASE_VERSION=latest
+
 RUN apt-get update && apt-get install -y curl && \
-    curl -L https://downloads.metabase.com/latest/metabase.jar -o metabase.jar && \
+    curl -L https://downloads.metabase.com/${METABASE_VERSION}/metabase.jar -o metabase.jar && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Run Metabase when the container launches
 CMD ["java", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "-jar", "metabase.jar"]


### PR DESCRIPTION
1. Get latest Metabase version from Metabase's Github repo: https://github.com/metabase/metabase
2. Check if Docker tag already exists on https://hub.docker.com/repository/docker/stephaneturquay/metabase-arm64
3. Log in to Docker Hub
4. Build and Push the newly built image with the "current version" and "latest" tags